### PR TITLE
Fix description and weblink doesn't display if there is no image

### DIFF
--- a/app/views/explore2.sidebar.box.html
+++ b/app/views/explore2.sidebar.box.html
@@ -24,7 +24,7 @@
 						<span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
 						{{'BOX_BOXDETAILSINFO'|translate}}
 					</uib-alert>
-					<div class="thumbnail" ng-hide="(!selectedMarker.image || selectedMarker.image === '')">
+					<div class="thumbnail">
 						<img id="image" ng-src="{{ (selectedMarker.image && selectedMarker.image != '') && 'userimages/'+selectedMarker.image || 'images/placeholder.png' }}" alt="Image for {{ selectedMarker.name }}">
 						<span ng-show="selectedMarker.description && selectedMarker.description != ''"><br/>{{ selectedMarker.description }}</span>
 						<span ng-show="selectedMarker.weblink && selectedMarker.weblink != ''"><br/><br/><a href="{{ selectedMarker.weblink }}" target="_blank">{{ selectedMarker.weblink }}</a></span>


### PR DESCRIPTION
If there is no image specified, you can't see the description nor the specified weblink. 

There is already a default image specified, but it won't be used, because the complete container is hidden if there is no image.

Example the active box at the top of Hamburg "Sebas SenseBox" (not my own one - just found a random example) 