### PR TITLE
smaller docker image, remove karma-phantomjs-launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "karma": "^1.5.0",
     "karma-html-reporter": "^0.2.7",
     "karma-mocha": "^1.3.0",
-    "karma-phantomjs-launcher": "^1.0.2",
     "load-grunt-tasks": "~3.4.0",
     "mocha": "^3.2.0",
     "serve-static": "^1.10.2",

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,6 @@ IFS=$'\n\t'
 
 # copy all files to the shared directory
 mkdir -p /usr/src/app/dist
-cp -rf /usr/src/osem/dist/* /usr/src/app/dist/
+cp -rf /osem-dist/* /usr/src/app/dist/
 
 exec /bin/true


### PR DESCRIPTION
This pull request has the following changes:
- Use `node:4-slim` image as base
- Remove `karma-phantom-js-launcher` from `package.json`. The package caused issues for building the image. I don't know if its required for testing or not..

The resulting image weighs 457 MB instead of the current 981 MB