### PR TITLE
Update travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,14 @@ script:
       export OPENSENSEMAP_MAPTILES_URL=$OPENSENSEMAP_MAPTILES_URL_DEV;
     fi
   - npm run build
-  - docker build -t $IMAGE_NAME:$TRAVIS_BRANCH .
+  - docker build -t $IMAGE_NAME:$TRAVIS_BRANCH-temp .
 
 after_success:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+
+  - docker pull $IMAGE_NAME:$TRAVS_BRANCH
+  - docker tag $IMAGE_NAME:$TRAVS_BRANCH $IMAGE_NAME:$TRAVIS_BRANCH-rollback
+  - docker push $IMAGE_NAME:$TRAVIS_BRANCH-rollback
+
+  - docker tag $IMAGE_NAME:$TRAVIS_BRANCH-temp $IMAGE_NAME:$TRAVIS_BRANCH
   - docker push $IMAGE_NAME:$TRAVIS_BRANCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,28 @@
 sudo: required
-
-language: node_js
-
 services:
   - docker
 
-before_install:
-  - npm install -g grunt-cli
+language: node_js
+node_js:
+  - '6'
 
-before_script:
-  - if [ "$TRAVIS_BRANCH" == "master" ]; then
-    docker build --build-arg OPENSENSEMAP_API_URL=$OPENSENSEMAP_API_URL --build-arg OPENSENSEMAP_MAPTILES_URL=$OPENSENSEMAP_MAPTILES_URL -t senseboxdevs/osem .;
-    elif [ "$TRAVIS_BRANCH" == "development" ]; then
-    docker build --build-arg OPENSENSEMAP_API_URL=$OPENSENSEMAP_API_URL_DEV --build-arg OPENSENSEMAP_MAPTILES_URL=$OPENSENSEMAP_MAPTILES_URL_DEV -t senseboxdevs/osem:development .;
+cache:
+  directories:
+  - node_modules
+  - "$HOME/.cache/bower"
+  - "$HOME/.npm"
+
+before_install:
+  - npm install -g grunt-cli bower
+
+script:
+  - if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+      export OPENSENSEMAP_API_URL=$OPENSENSEMAP_API_URL_MASTER;
+      export OPENSENSEMAP_MAPTILES_URL=$OPENSENSEMAP_MAPTILES_URL_MASTER;
     fi
+  - npm run build
+  - docker build -t $IMAGE_NAME:$TRAVIS_BRANCH .
 
 after_success:
-  - if [ "$TRAVIS_BRANCH" == "master" ]; then
-    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-    docker push senseboxdevs/osem:latest;
-    elif [ "$TRAVIS_BRANCH" == "development" ]; then
-    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-    docker push senseboxdevs/osem:development;
-    fi
-
-branches:
-  only:
-    - master
-    - development
+  - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+  - docker push $IMAGE_NAME:$TRAVIS_BRANCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ before_install:
   - npm install -g grunt-cli bower
 
 script:
-  - if [[ "$TRAVIS_BRANCH" == "master" ]]; then
-      export OPENSENSEMAP_API_URL=$OPENSENSEMAP_API_URL_MASTER;
-      export OPENSENSEMAP_MAPTILES_URL=$OPENSENSEMAP_MAPTILES_URL_MASTER;
+  - if [[ "$TRAVIS_BRANCH" != "master" ]]; then
+      export OPENSENSEMAP_API_URL=$OPENSENSEMAP_API_URL_DEV;
+      export OPENSENSEMAP_MAPTILES_URL=$OPENSENSEMAP_MAPTILES_URL_DEV;
     fi
   - npm run build
   - docker build -t $IMAGE_NAME:$TRAVIS_BRANCH .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,6 @@
-FROM digitallyseamless/nodejs-bower-grunt:5
+FROM busybox:1
 
-# Setup build folder
-RUN mkdir -p /usr/src/osem
-WORKDIR /usr/src/osem
+COPY ./dist /usr/src/osem/dist
+COPY run.sh /usr/local/bin/run.sh
 
-ARG OPENSENSEMAP_API_URL
-ARG OPENSENSEMAP_MAPTILES_URL
-
-ENV OPENSENSEMAP_API_URL ${OPENSENSEMAP_API_URL:-https://api.opensensemap.org}
-ENV OPENSENSEMAP_MAPTILES_URL ${OPENSENSEMAP_MAPTILES_URL:-http://\{s\}.tile.openstreetmap.org/\{z\}/\{x\}/\{y\}.png}
-
-COPY package.json /usr/src/osem/
-RUN npm install
-COPY bower.json .bowerrc* /usr/src/osem/
-RUN bower install
-COPY . /usr/src/osem/
-RUN grunt build
-
-CMD ["./run.sh"]
+CMD ["run.sh"]

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "scripts": {
     "test": "grunt test",
+    "build": "bower install && grunt build",
     "docker-build": "docker build -t osem .",
     "docker-run": "docker run -p 8000:8000 -it --rm osem bash"
   }

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -euo pipefail
 IFS=$'\n\t'


### PR DESCRIPTION
This pull request updates the travis build to change the following things:
- run `grunt build` in the CI Environment then build a container image from `dist` folder
- reduces the container image to 8MB (was 975MB)
- lets travis run for all branches
- uses the branch name as image tag

Things to do after merging this pull request:
- Disable building for pull requests
- Add secrets:
`travis encrypt DOCKER_USERNAME="" DOCKER_PASSWORD="" OPENSENSEMAP_API_URL="" OPENSENSEMAP_API_URL_MASTER="" OPENSENSEMAP_MAPTILES_URL="" OPENSENSEMAP_MAPTILES_URL_MASTER="" IMAGE_NAME="" --add`