### PR TITLE
fixes for charts

### DIFF
--- a/app/components/charts.directive.js
+++ b/app/components/charts.directive.js
@@ -157,7 +157,10 @@
 
         $scope.$watch('chart.selectedMeasurement', function (newValue, oldValue) {
           if (angular.isDefined(newValue)) {
-            selectDatapoint(newValue);
+            var dataPoint = vm.chartData.find(function (v) {
+              return v.id == newValue.id;
+            });
+            selectDatapoint(dataPoint);
           } else {
             deselectDatapoint();
           }


### PR DESCRIPTION
Fixes the `undefined` unit in the chart tooltip when mouseovering a map measurement.

Another issue:
The charts never show the measurements of the latest two hours. Might be related to a timezone offset from UTC. @mpfeil