### PR TITLE
add data upload feature to dashboard

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -235,6 +235,7 @@
     <script src="scripts/controllers/account.box.edit.script.js"></script>
     <script src="scripts/controllers/account.box.edit.mqtt.js"></script>
     <script src="scripts/controllers/account.box.edit.ttn.js"></script>
+    <script src="scripts/controllers/account.box.dataupload.js"></script>
     <script src="scripts/services/account.js"></script>
     <script src="scripts/services/language.js"></script>
     <script src="scripts/services/opensensemapapi.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -109,6 +109,19 @@ angular
           requiresLogin: true
         }
       })
+      .state('account.dataupload', {
+        url: '/:id/dataupload',
+        views: {
+          'account': {
+            controller: 'DataUploadController',
+            controllerAs: 'dataupload',
+            templateUrl: 'views/account.box.dataupload.html'
+          }
+        },
+        params: {
+          box: {}
+        }
+      })
       .state('account.edit', {
         url: '/:id/edit',
         params: {

--- a/app/scripts/controllers/account.box.dataupload.js
+++ b/app/scripts/controllers/account.box.dataupload.js
@@ -1,0 +1,71 @@
+(function () {
+  'use strict';
+
+  angular
+    .module('openSenseMapApp')
+    .controller('DataUploadController', DataUploadController);
+
+  DataUploadController.$inject = ['$scope', '$state', 'OpenSenseMapAPI'];//, 'boxData', 'notifications'];
+
+  function DataUploadController ($scope, $state, OpenSenseMapAPI) {
+    var vm = this;
+    vm.error = '';
+    vm.success = false;
+    vm.dataFormat = 'text/csv';
+    vm.measurementData = '';
+    vm.dataTypes = {
+      'text/csv': {
+        name: 'CSV',
+        example: 'sensorID,value,timestamp,longitude,latitude,height',
+      },
+      'application/json': {
+        name: 'JSON',
+        example: '[{"sensor":"597d010ef8c8dd504e54621d", "value":"32.1"}, {"sensor":"597d010ef8c8dd504e54621d", "value":"12.3", "createdAt":"2017-01-01T00:00:00Z", "location": [180,90,10]}]',
+      },
+    };
+
+    vm.submitData = submitData;
+    vm.onFileSelect = onFileSelect;
+
+    activate();
+
+    ////
+
+    function activate () {
+      vm.fileReader = new FileReader();
+      vm.fileReader.onload = function (e) {
+        $scope.$apply(function() {
+          vm.measurementData = e.target.result;
+        });
+      };
+    }
+
+    function onFileSelect (event, $flow, file) {
+      event.preventDefault();
+      vm.error = '';
+      if (Object.keys(vm.dataTypes).indexOf(file.file.type) === -1) {
+        vm.error = { code: 'FORMAT' };
+        return;
+      } else {
+        vm.dataFormat = file.file.type;
+      }
+
+      vm.fileReader.readAsText(file.file);
+    }
+
+    function submitData () {
+      vm.success = false;
+      vm.error = '';
+
+      OpenSenseMapAPI
+        .postMeasurements($state.params.id, vm.measurementData, vm.dataFormat)
+        .then(function (result) {
+          vm.success = true;
+        })
+        .catch(function (err) {
+          vm.error = err;
+          console.error(err);
+        });
+    }
+  }
+})();

--- a/app/scripts/services/opensensemapapi.js
+++ b/app/scripts/services/opensensemapapi.js
@@ -16,7 +16,8 @@
       getBoxLocations: getBoxLocations,
       getSensors: getSensors,
       getSensorData: getSensorData,
-      idwInterpolation: idwInterpolation
+      idwInterpolation: idwInterpolation,
+      postMeasurements: postMeasurements,
     };
 
     return service;
@@ -77,6 +78,15 @@
 
           return measurements;
         })
+        .catch(failed);
+    }
+
+    function postMeasurements(boxId, measurements, format) {
+      var url = getUrl() + '/boxes/' + boxId + '/data';
+      return $http.post(url, measurements, {
+          headers: { 'content-type': format }
+        })
+        .then(success)
         .catch(failed);
     }
 

--- a/app/translations/de_DE.json
+++ b/app/translations/de_DE.json
@@ -260,5 +260,15 @@
 
   "CHART_TOOLTIP_PLACEHOLDER": "Für Details fahre mit der Maus über die Messpunkte",
   "BADGE_PLACEHOLDER_PREFIX": "Aktualisieren in",
-  "BADGE_PLACEHOLDER_SUFFIX": "Sek."
+  "BADGE_PLACEHOLDER_SUFFIX": "Sek.",
+  "DASHBOARD_DATAUPLOAD": "Daten-Upload",
+  "DATAUPLOAD_TITLE": "Manueller Daten-Upload",
+  "DATAUPLOAD_INFO": "Hier kannst du Messungen zu deiner senseBox manuell hochladen. Dies kann sinnvoll sein, wenn die senseBox die Daten nur auf eine SD-Karte loggt da kein direkets Kommunikationsmittel verfügbar ist. Lade entweder eine Datei hoch oder kopiere die Daten in das Textfeld. Die verfügbaren Datenformate sind <a href=\"https://docs.opensensemap.org/#api-Measurements-postNewMeasurements\" target=\"_blank\">hier</a> beschrieben.",
+  "DATAUPLOAD_SELECTFILE": "Wähle eine Datei",
+  "DATAUPLOAD_FORMAT": "Datenformat",
+  "DATAUPLOAD_DATA": "Messungsdaten",
+  "DATAUPLOAD_SUCCESS": "Messungen erfolgreich gespeichert!",
+  "DATAUPLOAD_ERR_FORMAT": "Ungültiges Datenformat",
+  "DATAUPLOAD_ERR_BadRequest": "Ungültige Sensor-ID",
+  "DATAUPLOAD_ERR_UnprocessableEntity": "Messung(en) konnten nicht gelesen werden"
 }

--- a/app/translations/en_US.json
+++ b/app/translations/en_US.json
@@ -261,5 +261,15 @@
 
   "CHART_TOOLTIP_PLACEHOLDER": "For details move the mouse over the datapoints",
   "BADGE_PLACEHOLDER_PREFIX": "Refreshing in",
-  "BADGE_PLACEHOLDER_SUFFIX": "secs"
+  "BADGE_PLACEHOLDER_SUFFIX": "secs",
+  "DASHBOARD_DATAUPLOAD": "Data upload",
+  "DATAUPLOAD_TITLE": "Manual Data Upload",
+  "DATAUPLOAD_INFO": "Here you can upload measurements for this senseBox. This can be of use for senseBoxes that log their measurements to a SD-card when no means of direct communication to opensensemap are available. Either select a file, or copy the data into the textfield. Accepted data formats are described <a href=\"https://docs.opensensemap.org/#api-Measurements-postNewMeasurements\" target=\"_blank\">here</a>.",
+  "DATAUPLOAD_SELECTFILE": "Select a file",
+  "DATAUPLOAD_FORMAT": "Data format",
+  "DATAUPLOAD_DATA": "Measurement data",
+  "DATAUPLOAD_SUCCESS": "Measurements successfully added!",
+  "DATAUPLOAD_ERR_FORMAT": "Invalid filetype",
+  "DATAUPLOAD_ERR_BadRequest": "Invalid sensor ID",
+  "DATAUPLOAD_ERR_UnprocessableEntity": "Could not parse measurements"
 }

--- a/app/views/account.box.dataupload.html
+++ b/app/views/account.box.dataupload.html
@@ -1,0 +1,62 @@
+<div class="container">
+  <div style="margin-top: 15px;">
+    <div uib-alert ng-show="dataupload.success" class="alert-success" close>
+      {{ 'DATAUPLOAD_SUCCESS' | translate }}
+    </div>
+    <div uib-alert ng-show="dataupload.error" class="alert-danger" close>
+      {{ 'DATAUPLOAD_ERR_'+dataupload.error.code|translate }}
+      <span ng-if="dataupload.error.message"> ({{dataupload.error.message}})</span>
+    </div>
+  </div>
+
+  <div class="row register">
+    <div class="col-md-3">
+      <ul class="nav nav-pills nav-stacked">
+        <li><a ui-sref="account.dashboard"><i class="fa fa-arrow-left fa-fw"></i> {{'BACK_TO_DASHBOARD'|translate}}</a></li>
+      </ul>
+    </div>
+
+    <div class="col-md-9">
+      <form name="dataUpload">
+        <div class="row">
+          <h2 style="margin-top: 0px; margin-bottom: 0px">{{'DATAUPLOAD_TITLE'|translate}}</h2>
+        </div>
+
+        <hr/>
+
+        <div class="row">
+          <div class="alert alert-info" ng-bind-html="'DATAUPLOAD_INFO'|translate"></div>
+        </div>
+
+        <div class="row" flow-init="{ singleFile: true }" flow-file-added="dataupload.onFileSelect($event, $flow, $file)">
+          <span class="btn btn-default" type="file" flow-btn flow-attrs="{ accept: 'text/csv,application/json' }">
+            {{'DATAUPLOAD_SELECTFILE'|translate}}
+          </span>
+        </div>
+
+        <div class="row">
+          <label for="dataFormat">{{'DATAUPLOAD_FORMAT'|translate}}</label>
+          <select name="dataFormat" class="form-control" ng-model="dataupload.dataFormat">
+            <option ng-repeat="(type, format) in dataupload.dataTypes" value="{{type}}">{{format.name}}</option>
+          </select>
+        </div>
+
+        <div class="row">
+          <label for="measurementData">{{'DATAUPLOAD_DATA'|translate}}</label>
+          <textarea name="measurementData" class="form-control" cols="30" rows="10"
+            ng-model="dataupload.measurementData"
+            placeholder="{{ dataupload.dataTypes[dataupload.dataFormat].example }}"
+            style="resize: none;"></textarea>
+        </div>
+
+        <div class="row">
+          <button type="button" class="btn btn-default btn-lg" ng-click="dataupload.submitData()" ng-disabled="dataupload.measurementData.length == 0">
+            <i class="glyphicon glyphicon-arrow-up"></i>
+            {{'UPLOAD'|translate}}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+</div>

--- a/app/views/account.dashboard.html
+++ b/app/views/account.dashboard.html
@@ -31,17 +31,24 @@
 
         <div class="actions">
           <div class="row row-no-gutter">
-            <div class="col-xs-6 col-sm-6 col-md-6">
+            <div class="col-xs-4 col-sm-4 col-md-4">
               <div class="action" ui-sref="explore.map.boxdetails({id: box._id})">
                 <h1>{{'LEGEND_SHOWALL' | translate}}</h1>
                 <i class="fa fa-map-marker fa-lg" aria-hidden="true"></i>
               </div>
             </div>
 
-            <div class="col-xs-6 col-sm-6 col-md-6">
+            <div class="col-xs-4 col-sm-4 col-md-4">
               <div class="action" ui-sref="account.edit.general({id: box._id, box: box})">
                 <h1>{{'CONFIG_EDIT' | translate}}</h1>
                 <i class="fa fa-pencil fa-lg" aria-hidden="true"></i>
+              </div>
+            </div>
+
+            <div class="col-xs-4 col-sm-4 col-md-4">
+              <div class="action" ui-sref="account.dataupload({id: box._id, box: box})">
+                <h1>{{'DASHBOARD_DATAUPLOAD' | translate}}</h1>
+                <i class="fa fa-table fa-lg" aria-hidden="true"></i>
               </div>
             </div>
 


### PR DESCRIPTION
Adds a `data upload` button for each box in the dashboard.
Clicking it shows a dialog with file upload / textarea allowing manual upload of measurements to this box.
Usecase: Boxes that log data to SD card or similar due to no available means of direct communication.