### PR TITLE
Fix translation for senseBox informations in all languages

### DIFF
--- a/app/views/explore2.sidebar.box.html
+++ b/app/views/explore2.sidebar.box.html
@@ -56,7 +56,7 @@
                     </span>
                   </div>
                   <div class="col-xs-10 sensor-measurement-info" >
-                    <div>{{sensor.title}}</div><br/>
+                    <div>{{sensor.title | translate}}</div><br/>
                     <div ng-if="sensor.lastMeasurement.createdAt" uib-tooltip="{{'LAST_MEASUREMENT_FROM' | translate }} {{ sensor.lastMeasurement.createdAt | amUtc | amLocal | amDateFormat:'l LTS'}}" tooltip-placement="top-right">
                       <span style="font-weight:bold;">{{sensor.lastMeasurement.value}} {{sensor.unit}}</span>
                       <span am-time-ago="sensor.lastMeasurement.createdAt" class="sensor-measurement-info-date"></span>


### PR DESCRIPTION
### Fix or Enhancement and description?
It's a fix. I'm not sure if there's an issue already open for it but I found something strange when I was working on the portuguese translations for the Hacktoberfest. I've noticed that when I click on a senseBox, all the informations are shown in german, no matter the language I choose.

Here is the information shown in german when I choose portuguese:

![before](https://user-images.githubusercontent.com/13180987/31357665-04cf3f60-ad19-11e7-8bdb-5d2b80a3ae35.png)

And here is the information shown in german when I choose italian:

![before_italian](https://user-images.githubusercontent.com/13180987/31358219-1e659c60-ad1b-11e7-9eb7-246ac4f2eef8.png)

And my PR is just a small fix to show the translation for the informations correctly (in this case there's not a translation key for `UV-Intensität` in portuguese but I've added it on the PR #222 ):

![after](https://user-images.githubusercontent.com/13180987/31357685-22e498a6-ad19-11e7-83f1-d6dbfe92cccc.png)

Italian language selected after my fix:

![after_italian](https://user-images.githubusercontent.com/13180987/31358257-3cf8c012-ad1b-11e7-9c96-f57f03fd23bc.png)

### Environment
- OS: Ubuntu 16.04.1 Xenial x64
- Browser & Version: Google Chrome 60.0.3112.90 x64