### PR TITLE
fix #227 - show grouptag in registration summary

### DIFF
--- a/app/views/register.html
+++ b/app/views/register.html
@@ -411,7 +411,7 @@
                   </tr>
                   <tr>
                     <td style="width: 50%;">{{'GROUP_NAME'|translate}}</td>
-                    <td style="width: 50%;"><strong>{{register.newSenseBox.tag}}</strong></td>
+                    <td style="width: 50%;"><strong>{{register.tag}}</strong></td>
                   </tr>
                   <tr>
                     <td style="width: 50%;">{{'STATION_PLACEMENT'|translate}}</td>
@@ -463,7 +463,7 @@
                   </tr>
                   <tr>
                     <td style="width: 50%;">{{'GROUP_NAME'|translate}}</td>
-                    <td style="width: 50%;"><strong>{{register.newSenseBox.tag}}</strong></td>
+                    <td style="width: 50%;"><strong>{{register.newSenseBox.grouptag}}</strong></td>
                   </tr>
                   <tr>
                     <td style="width: 50%;">{{'STATION_PLACEMENT'|translate}}</td>


### PR DESCRIPTION
This pull request fixes the Issue #227 

The stations grouptag is now shown correctly in the registration.