### PR TITLE
postMeasurements with access token, fixes #378

### DIFF
--- a/app/scripts/controllers/account.box.dataupload.js
+++ b/app/scripts/controllers/account.box.dataupload.js
@@ -58,7 +58,7 @@
       vm.success = false;
       vm.error = '';
       OpenSenseMapAPI
-        .postMeasurements($state.params.id, vm.measurementData, vm.dataFormat,$state.params.box.access_token)
+        .postMeasurements($state.params.id, vm.measurementData, vm.dataFormat, $state.params.box.access_token)
         .then(function () {
           vm.success = true;
         })

--- a/app/scripts/controllers/account.box.dataupload.js
+++ b/app/scripts/controllers/account.box.dataupload.js
@@ -57,9 +57,8 @@
     function submitData () {
       vm.success = false;
       vm.error = '';
-
       OpenSenseMapAPI
-        .postMeasurements($state.params.id, vm.measurementData, vm.dataFormat)
+        .postMeasurements($state.params.id, vm.measurementData, vm.dataFormat,$state.params.box.access_token)
         .then(function () {
           vm.success = true;
         })

--- a/app/scripts/services/opensensemapapi.js
+++ b/app/scripts/services/opensensemapapi.js
@@ -97,7 +97,7 @@
 
       return $http
         .post(url, measurements, {
-          headers: { 'content-type': format , 'Authorization': access_token}
+          headers: { 'content-type': format , 'Authorization': access_token }
         })
         .then(success)
         .catch(failed);

--- a/app/scripts/services/opensensemapapi.js
+++ b/app/scripts/services/opensensemapapi.js
@@ -92,12 +92,12 @@
         .catch(failed);
     }
 
-    function postMeasurements (boxId, measurements, format) {
+    function postMeasurements (boxId, measurements, format,access_token) {
       var url = getUrl() + '/boxes/' + boxId + '/data';
 
       return $http
         .post(url, measurements, {
-          headers: { 'content-type': format }
+          headers: { 'content-type': format ,'Authorization': access_token}
         })
         .then(success)
         .catch(failed);

--- a/app/scripts/services/opensensemapapi.js
+++ b/app/scripts/services/opensensemapapi.js
@@ -92,7 +92,7 @@
         .catch(failed);
     }
 
-    function postMeasurements (boxId, measurements, format,access_token) {
+    function postMeasurements (boxId, measurements, format, access_token) {
       var url = getUrl() + '/boxes/' + boxId + '/data';
 
       return $http

--- a/app/scripts/services/opensensemapapi.js
+++ b/app/scripts/services/opensensemapapi.js
@@ -97,7 +97,7 @@
 
       return $http
         .post(url, measurements, {
-          headers: { 'content-type': format ,'Authorization': access_token}
+          headers: { 'content-type': format , 'Authorization': access_token}
         })
         .then(success)
         .catch(failed);


### PR DESCRIPTION

### Fix or Enhancement and description?
When posting measurements from OSM (e.g. via manual data upload) an access token is provided. 



### Environment
- OS: Write here
- Browser & Version: Write here