### PR TITLE
Feat display eric

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - feat_display_eric
   pull_request:
     branches:
       - master

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - feat_display_eric
   pull_request:
     branches:
       - master

--- a/app/scripts/controllers/account.box.edit.script.js
+++ b/app/scripts/controllers/account.box.edit.script.js
@@ -10,7 +10,7 @@
   function EditBoxScriptController (boxData, AccountService) {
     var vm = this;
     vm.box = boxData;
-
+    vm.display_enabled = false;
     vm.serialPort = 'Serial1';
     vm.boxScript = '';
     vm.showConfiguration = false;
@@ -42,6 +42,7 @@
     ////
 
     function activate () {
+      console.log(boxData)
       if (boxData.model.startsWith('homeV2Wifi')) {
         vm.showConfiguration = true;
         vm.showWifiConfiguration = true;
@@ -94,7 +95,9 @@
         password: vm.wifi.password,
         devEUI: vm.ttn.devEUI,
         appEUI: vm.ttn.appEUI,
-        appKey: vm.ttn.appKey
+        appKey: vm.ttn.appKey,
+        display_enabled:vm.display_enabled
+
       })
         .then(function (response) {
           vm.boxScript = response;

--- a/app/scripts/controllers/account.box.edit.script.js
+++ b/app/scripts/controllers/account.box.edit.script.js
@@ -42,7 +42,6 @@
     ////
 
     function activate () {
-      console.log(boxData)
       if (boxData.model.startsWith('homeV2Wifi')) {
         vm.showConfiguration = true;
         vm.showWifiConfiguration = true;

--- a/app/scripts/controllers/register.js
+++ b/app/scripts/controllers/register.js
@@ -43,7 +43,7 @@
       windSpeedPort: 'C',
       bmePhenomenon: 'tempHumiPress'
     };
-
+    vm.display_enabled = false;
     vm.wifi = {
       ssid: '',
       pasword: ''
@@ -199,7 +199,8 @@
         password: vm.wifi.password,
         devEUI: vm.ttn.devEUI,
         appEUI: vm.ttn.appEUI,
-        appKey: vm.ttn.appKey
+        appKey: vm.ttn.appKey,
+        display_enabled:vm.display_enabled
       })
         .then(function (response) {
           vm.boxScript = response;

--- a/app/views/account.box.edit.script.html
+++ b/app/views/account.box.edit.script.html
@@ -63,6 +63,19 @@
         </div>
       </div>
     </div>
+    <div class="form-group" ng-if="script.box.model === 'homeV2Wifi' || script.box.model === 'homeV2WifiFeinstaub'">
+      <div style="text-align: left;">
+        <div class="checkbox checkbox-success checkbox-inline"
+          style="vertical-align: middle;">
+          <input type="checkbox" id="display_enabled" ng-model="script.display_enabled" ng-change="script.generateScript()">
+          <label for="display_enabled"> </label>
+        </div>
+        <img
+          src="https://sensebox.kaufen/api/public/uploads/1524084885676-oled_top.png"
+          style="vertical-align: middle; height: 60px; width: 80px;" />
+        <span style="vertical-align: middle;">{{'DISPLAY_ENABLED' | translate}}</span>
+      </div>
+    </div>
     <div class="form-group break" ng-if="script.showWifiConfiguration">
       <label for="ssid">WiFi SSID</label>
       <div class="input-group" uib-tooltip="{{'DATA_NOT_STORED'|translate}}" tooltip-placement="top"

--- a/app/views/account.box.register.html
+++ b/app/views/account.box.register.html
@@ -1469,6 +1469,19 @@
               ng-if="register.newSenseBox.model === 'homeV2WifiFeinstaub' || register.newSenseBox.model === 'homeV2Wifi' || register.newSenseBox.model === 'homeV2Lora'">
               <h5 ng-bind-html="'COMPILE_SKETCH'|translate"></h5>
               <div>
+                <div class="form-group" ng-if="register.newSenseBox.model === 'homeV2Wifi' || register.newSenseBox.model === 'homeV2WifiFeinstaub'">
+                  <div style="text-align: left;">
+                    <div class="checkbox checkbox-success checkbox-inline"
+                      style="vertical-align: middle;">
+                      <input type="checkbox" id="display_enabled" ng-model="register.display_enabled" ng-change="register.generateScript()">
+                      <label for="display_enabled"> </label>
+                    </div>
+                    <img
+                      src="https://sensebox.kaufen/api/public/uploads/1524084885676-oled_top.png"
+                      style="vertical-align: middle; height: 60px; width: 80px;" />
+                    <span style="vertical-align: middle;">{{'DISPLAY_ENABLED' | translate}}</span>
+                  </div>
+                </div>
                 <div class="form-group" ng-if="register.newSenseBox.sensorTemplates.includes('sds 011')">
                   <label for="serialport">{{'PORT'|translate}}</label>
                   <div class="input-group" uib-tooltip-template="'tooltip_serialports.html'" tooltip-placement="bottom"


### PR DESCRIPTION

### Enhancement 
At register & at the script tab the user can now enable the display. Enabling the display will prompt the API to request a new sketch from the node-sketch-templater which will set a `#define DISPLAY_CONNECTED` in the Arduino Sketch. 


Sketch, API and UI have been tested beforehand. The changes to the registration can be explored on testing.opensensemap.org 
However, for the whole process to work [changes to the node-sketch-templater](https://github.com/sensebox/node-sketch-templater/pull/40) must first be implemented. 




### Environment
- OS: Write here
- Browser & Version: Write here