### PR TITLE
refactor(i18n): Load translations by unpkg

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -420,12 +420,6 @@ module.exports = function (grunt) {
         files: [
           {
             expand: true,
-            cwd: 'node_modules/@sensebox/opensensemap-i18n/dist',
-            dest: '.tmp/translations',
-            src: ['de_DE.json', 'en_US.json']
-          },
-          {
-            expand: true,
             cwd: 'node_modules/angular-i18n/',
             dest: '.tmp/translations/angular',
             src: ['angular-locale_{<%= pkg.languages %>}.js']
@@ -451,12 +445,6 @@ module.exports = function (grunt) {
             'fonts/*.*',
             'fonts/webfonts/*.*'
           ]
-        },
-        {
-          expand: true,
-          cwd: 'node_modules/@sensebox/opensensemap-i18n/dist',
-          dest: 'dist/translations',
-          src: ['de_DE.json', 'en_US.json']
         },
         {
           expand: true,
@@ -592,7 +580,6 @@ module.exports = function (grunt) {
           { expand: true, src: ['dist/scripts/*.scripts.js'], dest: './', extDot: 'last', ext: '.js.gz' },
           { expand: true, src: ['dist/styles/*.css'], dest: './', extDot: 'last', ext: '.css.gz' },
           { expand: true, src: ['dist/translations/angular/*.js'], dest: './', extDot: 'last', ext: '.js.gz' },
-          { expand: true, src: ['dist/translations/*.json'], dest: './', extDot: 'last', ext: '.json.gz' },
           { expand: true, src: ['dist/images/*.svg'], dest: './', extDot: 'last', ext: '.svg.gz' }
 
         ]
@@ -609,7 +596,6 @@ module.exports = function (grunt) {
           { expand: true, src: ['dist/scripts/*.scripts.js'], dest: './', extDot: 'last', ext: '.js.br' },
           { expand: true, src: ['dist/styles/*.css'], dest: './', extDot: 'last', ext: '.css.br' },
           { expand: true, src: ['dist/translations/angular/*.js'], dest: './', extDot: 'last', ext: '.js.br' },
-          { expand: true, src: ['dist/translations/*.json'], dest: './', extDot: 'last', ext: '.json.br' },
           { expand: true, src: ['dist/images/*.svg'], dest: './', extDot: 'last', ext: '.svg.br' }
         ]
       }
@@ -719,14 +705,7 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask('languages', '', function () {
-    var target = grunt.option('target');
-    var translationsFolder = '.tmp/translations/';
     var targetFile = '.tmp/index.html';
-    if (target === 'build' || target === 'testBuild') {
-      translationsFolder = 'dist/translations/';
-      targetFile = 'dist/index.html';
-    }
-
     var fs = require('fs');
     var done = this.async();
     fs.readFile('app/index.html', 'utf8', function (err, data) {
@@ -734,14 +713,13 @@ module.exports = function (grunt) {
         return console.log(err);
       }
       var html = '';
-      grunt.file.recurse(translationsFolder, function (abspath, rootdir, subdir, filename) {
-        if (subdir !== undefined) { return; }
-        if (filename.indexOf('disabled') === -1) {
-          var languageCode = filename.split('.')[0];
-          var language = languageCode.split('_')[0];
-          html = html + ('<li><a ng-click="header.changeLang(\'' + languageCode + '\')"><span class="lang-sm lang-lbl-full" lang="' + language + '"></span></a></li>');
-        }
-      });
+      var pkg = grunt.file.readJSON('package.json');
+      for (let index = 0; index < pkg.i18n.length; index++) {
+        const languageCode = pkg.i18n[index];
+        var language = languageCode.split('_')[0];
+        html = html + ('<li><a ng-click="header.changeLang(\'' + languageCode + '\')"><span class="lang-sm lang-lbl-full" lang="' + language + '"></span></a></li>');
+      }
+
       var resultStart = data.split('<!-- languages-start -->');
       var resultEnd = data.split('<!-- languages-end -->');
       var res = `${resultStart[0]}<!-- languages-start -->${html}<!-- languages-end -->${resultEnd[1]}`;

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -705,7 +705,11 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask('languages', '', function () {
+    var target = grunt.option('target');
     var targetFile = '.tmp/index.html';
+    if (target === 'build' || target === 'testBuild') {
+      targetFile = 'dist/index.html';
+    }
     var fs = require('fs');
     var done = this.async();
     fs.readFile('app/index.html', 'utf8', function (err, data) {

--- a/app/index.html
+++ b/app/index.html
@@ -352,8 +352,6 @@
   <script src="bower_components/ng-flow/dist/ng-flow.js"></script>
   <script src="bower_components/angular-translate/angular-translate.js"></script>
   <script src="bower_components/angular-translate-loader-static-files/angular-translate-loader-static-files.js"></script>
-  <script
-    src="bower_components/angular-translate-loader-static-files/angular-translate-loader-static-files.js"></script>
   <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
   <script src="bower_components/moment/moment.js"></script>
   <script src="bower_components/moment/locale/de.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -448,7 +448,7 @@
     }])
     .config(['$translateProvider', function ($translateProvider) {
       $translateProvider.useStaticFilesLoader({
-        prefix: '../translations/',
+        prefix: 'https://unpkg.com/@sensebox/opensensemap-i18n@latest/dist/',
         suffix: '.json'
       });
       $translateProvider.use('de_DE');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,6 @@
       "integrity": "sha512-MhwFHGmt7X/Wb/aISS/pJvBuO8HqpkVfB8GsUKOosWEfvug4cTN7N/pXBOxINukG34LcKDLp1xdyxuEo64CMSw==",
       "dev": true
     },
-    "@sensebox/opensensemap-i18n": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@sensebox/opensensemap-i18n/-/opensensemap-i18n-4.0.1.tgz",
-      "integrity": "sha512-xCOm7mxxr/rrOXKF8LGxLih0EWmGPv441nLxnxqpbHsqf5FK52JqLuDz7U/V0BCjStH7PIcWpY0+rNiOy2Cy/A=="
-    },
     "JSONStream": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "opensensemap",
   "version": "2.4.10",
   "dependencies": {
-    "@sensebox/opensensemap-i18n": "4.0.1",
     "angular-i18n": "^1.6.7",
     "node": "^10.19.0"
   },
@@ -80,5 +79,9 @@
   "languages": [
     "de",
     "en"
+  ],
+  "i18n": [
+    "de_DE",
+    "en_US"
   ]
 }


### PR DESCRIPTION
### Fix or Enhancement and description?

Use unpkg to directly load translation files from npm.
If there are changes within the `opensensemap-i18n` package you don´t need to rebuild the frontend
because the `latest` tag is fetched by `unpkg`.