### PR TITLE
fix(edit): concat grouptags

### DIFF
--- a/app/scripts/controllers/account.box.edit.general.js
+++ b/app/scripts/controllers/account.box.edit.general.js
@@ -21,6 +21,9 @@
     ////
 
     function activate () {
+      // Concat grouptags
+      boxData.grouptag = boxData.grouptag.join(',');
+
       angular.copy(boxData, vm.editingMarker);
     }
 


### PR DESCRIPTION
Concat grouptags of a device to string and fix split error on saving.