### PR TITLE
use 4.3.0 i18n version

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -491,7 +491,7 @@
       '$translateProvider',
       function ($translateProvider) {
         $translateProvider.useStaticFilesLoader({
-          prefix: 'https://unpkg.com/@sensebox/opensensemap-i18n@latest/dist/',
+          prefix: 'https://unpkg.com/@sensebox/opensensemap-i18n@4.3.0/dist/',
           suffix: '.json',
         });
         $translateProvider.use('de_DE');


### PR DESCRIPTION
@latest would use a deprecated package if its set on latest. 


tried to release 4.3.2 version of i18n but no /dist folder got build. dont know how to proceed so im hard coding version 4.3.0 in the hopes to never alter texts on the osem again